### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # a2 Bluebottle OS
 
-That is a copy of original [A2 Repository](https://trac.inf.ethz.ch/trac/lecturers/a2)
+This is a copy of original [A2 Repository](https://trac.inf.ethz.ch/trac/lecturers/a2) which moved in the mean time to [a new place](http://cas.inf.ethz.ch/projects/a2/repository). This copy here is obsoleted by [metacore's active, but unoffical mirror copy](https://github.com/metacore/A2OS).
 
 Also extra ISO image [A2_Rev-6498_serial-trace.iso](http://sourceforge.net/projects/a2oberon/files/)
 


### PR DESCRIPTION
added note at the beginning that the A2 mirror is obsoleted by metacore's mirror